### PR TITLE
Always use LF line endings for *.sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This is necessary when checking out the repository on Windows