### PR TITLE
Add option to exit immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following environment variables can be used to customize the Certbot contain
 | `DEBUG`                | Enable debug mode (prints more information to the console)            | `false`                    |
 | `PUID`                 | The user ID to run certbot as                                       | `0`                    |
 | `PGID`                 | The group ID to run certbot as                                        | `0`                    |
-| `RENEWAL_INTERVAL`     | Interval between certificate renewal checks                         | 43200 seconds (12 hours) |
+| `RENEWAL_INTERVAL`     | Interval between certificate renewal checks                         | 43200 seconds (12 hours), 0 to exit immediately |
 | `REPLACE_SYMLINKS`     | Replaces symlinks with direct copies of the files they reference (required for Windows) | `false`                    |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following environment variables can be used to customize the Certbot contain
 | `DEBUG`                | Enable debug mode (prints more information to the console)            | `false`                    |
 | `PUID`                 | The user ID to run certbot as                                       | `0`                    |
 | `PGID`                 | The group ID to run certbot as                                        | `0`                    |
-| `RENEWAL_INTERVAL`     | Interval between certificate renewal checks                         | 43200 seconds (12 hours), 0 to exit immediately |
+| `RENEWAL_INTERVAL`     | Interval between certificate renewal checks. Set to `0` to disable renewals and only run once.                         | 43200 seconds (12 hours) |
 | `REPLACE_SYMLINKS`     | Replaces symlinks with direct copies of the files they reference (required for Windows) | `false`                    |
 
 ## Usage

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -193,8 +193,9 @@ else
     # Run certbot initially to get the certificates
     run_certbot
 
-    # Exit if interval is zero
+    # If RENEWAL_INTERVAL is set to 0, do not attempt to renew certificates and exit immediately
     if [ "$RENEWAL_INTERVAL" = "0" ]; then
+        echo "Let's Encrypt Renewals are disabled because RENEWAL_INTERVAL=0. Running once and exiting..."
         cleanup
     fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -193,6 +193,11 @@ else
     # Run certbot initially to get the certificates
     run_certbot
 
+    # Exit if interval is zero
+    if [ "$RENEWAL_INTERVAL" = "0" ]; then
+        cleanup
+    fi
+
     # Infinite loop to keep the container running and periodically check for renewals
     while true; do
         # POSIX-compliant way to show next run time


### PR DESCRIPTION
Allows user to exit after generating certs. This works by allowing the user to set `0` in the `RENEWAL_INTERVAL` variable which otherwise would be an invalid setting.