### PR TITLE
Update entrypoint.sh

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -116,7 +116,7 @@ run_certbot() {
         --agree-tos \
         --non-interactive \
         --strict-permissions \
-        --preferred-chain="ISRG Root X1
+        --preferred-chain="ISRG Root X1"
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Error: certbot command failed with exit code $exit_code"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -115,7 +115,8 @@ run_certbot() {
         --server "$CERTBOT_SERVER" \
         --agree-tos \
         --non-interactive \
-        --strict-permissions
+        --strict-permissions \
+        --preferred-chain="ISRG Root X1
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Error: certbot command failed with exit code $exit_code"


### PR DESCRIPTION
Recently, after the **DST Root CA X3** root certificate expired, I started running into issues with Android’s Private DNS (DNS-over‑TLS) while using my self‑hosted AdGuard Home that is secured with Let’s Encrypt certificates.  

I eventually traced the problem to how Android validates the certificate trust chain: by default, Let’s Encrypt still serves a chain that ends in the now‑expired **DST Root CA X3** (for legacy compatibility), and some Android versions reject it.  


** Problem **
Android DoT / Let’s Encrypt chain issue” concerning compatibility when using the expired DST Root CA X3

** Solution (from issue [#25](https://github.com/serversideup/docker-certbot-dns-cloudflare/issues/25)):**

Add the flag `--preferred‑chain="ISRG Root X1"` to the `certonly` command in your Dockerfile’s entrypoint. This forces Let’s Encrypt to issue a certificate using the ISRG Root X1 chain instead of including the expired **DST Root CA X3**, improving compatibility with Android DNS-over‑TLS. 