### PR TITLE
Add proxy support and optional email

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following environment variables can be used to customize the Certbot contain
 | `CERTBOT_DOMAINS`      | Comma-separated list of domains for which to obtain the certificate (example: `example.com,www.example.com`) | - |
 | `CERTBOT_CERT_NAME`    | Explicit certificate name to update/modify ([See official docs →](https://eff-certbot.readthedocs.io/en/stable/using.html#changing-a-certificate-s-domains)) | - |
 | `CERTBOT_EXPAND`       | **DEPRECATED**: Expand existing certificate to add domains (use CERTBOT_CERT_NAME instead, [see official docs →](https://eff-certbot.readthedocs.io/en/stable/using.html#re-creating-and-updating-existing-certificates)) | `false` |
-| `CERTBOT_EMAIL`        | Email address for Let's Encrypt notifications                       | - |
+| `CERTBOT_EMAIL`        | **Optional.** Email address for Let's Encrypt notifications. If omitted, the container will register with Let's Encrypt using `--register-unsafely-without-email`.                       | - |
 | `CERTBOT_KEY_TYPE`     | Type of private key to generate                                     | `ecdsa` |
 | `CERTBOT_SERVER`       | The ACME server URL                                                 | `https://acme-v02.api.letsencrypt.org/directory` |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare API token for DNS authentication (see below how to create one)                         | - |
@@ -70,6 +70,11 @@ The following environment variables can be used to customize the Certbot contain
 | `PGID`                 | The group ID to run certbot as                                        | `0`                    |
 | `RENEWAL_INTERVAL`     | Interval between certificate renewal checks. Set to `0` to disable renewals and only run once.                         | 43200 seconds (12 hours) |
 | `REPLACE_SYMLINKS`     | Replaces symlinks with direct copies of the files they reference (required for Windows) | `false`                    |
+| `PROXY_TYPE`           | Proxy type for routing Certbot traffic. Supported values: `none`, `socks5`, `socks4`, `http`, `https`. When `none`, no proxy is used. | `none` |
+| `PROXY_HOST`           | Proxy hostname or IP address, required when `PROXY_TYPE` is not `none`. | - |
+| `PROXY_PORT`           | Proxy port, required when `PROXY_TYPE` is not `none`. | - |
+| `PROXY_USERNAME`       | Optional username for authenticated proxies. | - |
+| `PROXY_PASSWORD`       | Optional password for authenticated proxies. | - |
 
 ### Creating a Cloudflare API Token
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,12 +20,17 @@ ENV CERTBOT_DOMAINS="" \
     PUID=0 \
     PGID=0 \
     RENEWAL_INTERVAL=43200 \
-    REPLACE_SYMLINKS=false
+    REPLACE_SYMLINKS=false \
+    PROXY_TYPE="none" \
+    PROXY_HOST="" \
+    PROXY_PORT="" \
+    PROXY_USERNAME="" \
+    PROXY_PASSWORD=""
 
 COPY --chmod=700 entrypoint.sh /entrypoint.sh
 
 RUN apk update && \
-    apk add --no-cache shadow su-exec && \
+    apk add --no-cache shadow su-exec proxychains-ng && \
     addgroup -g "${CERTBOT_GID}" "${CERTBOT_GROUP}" && \
     adduser -u "${CERTBOT_UID}" -G "${CERTBOT_GROUP}" -D -H "${CERTBOT_USER}" && \
     mkdir -p /var/log/letsencrypt && \

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -88,6 +88,54 @@ is_default_privileges() {
     [ "${PUID:-$default_uid}" = "$default_uid" ] && [ "${PGID:-$default_gid}" = "$default_gid" ]
 }
 
+configure_proxychains() {
+    # Build /etc/proxychains.conf from environment variables when a proxy is configured
+    proxy_type="${PROXY_TYPE:-none}"
+
+    if [ "$proxy_type" = "none" ]; then
+        debug_print "Proxychains proxy not configured (PROXY_TYPE=none)."
+        return 0
+    fi
+
+    case "$proxy_type" in
+        socks5|socks4|http|https)
+            ;;
+        *)
+            echo "Error: Invalid PROXY_TYPE '$proxy_type'. Supported values: socks5, socks4, http, https, none"
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$PROXY_HOST" ] || [ -z "$PROXY_PORT" ]; then
+        echo "Error: PROXY_HOST and PROXY_PORT must be set when PROXY_TYPE is not 'none'"
+        exit 1
+    fi
+
+    # Use the default path that proxychains4 inside this image reads by default
+    conf_dir="/etc/proxychains"
+    conf_path="${conf_dir}/proxychains.conf"
+
+    mkdir -p "$conf_dir"
+
+    debug_print "Generating $conf_path for proxy $proxy_type $PROXY_HOST:$PROXY_PORT"
+
+    {
+        echo "strict_chain"
+        echo "proxy_dns"
+        echo
+        echo "[ProxyList]"
+        if [ -n "$PROXY_USERNAME" ] && [ -n "$PROXY_PASSWORD" ]; then
+            echo "${proxy_type} ${PROXY_HOST} ${PROXY_PORT} ${PROXY_USERNAME} ${PROXY_PASSWORD}"
+        else
+            echo "${proxy_type} ${PROXY_HOST} ${PROXY_PORT}"
+        fi
+    } > "$conf_path"
+
+    # Ensure the certbot user can read the config
+    chmod 644 "$conf_path"
+    chown "${default_unprivileged_user}:${default_unprivileged_group}" "$conf_path" 2>/dev/null || true
+}
+
 run_certbot() {
     # Ensure the log directory is set to 700
     chmod 700 /var/log/letsencrypt
@@ -97,6 +145,12 @@ run_certbot() {
         certbot_cmd="certbot"
     else
         certbot_cmd="su-exec ${default_unprivileged_user} certbot"
+    fi
+
+    # Optionally wrap certbot with proxychains to route traffic via a proxy
+    if [ "${PROXY_TYPE:-none}" != "none" ]; then
+        debug_print "Wrapping certbot with proxychains4 based on proxy settings"
+        certbot_cmd="proxychains4 ${certbot_cmd}"
     fi
 
     debug_print "Running certbot with command: $certbot_cmd"
@@ -115,13 +169,20 @@ run_certbot() {
     fi
 
     # Run certbot command
+    email_args=""
+    if [ -n "$CERTBOT_EMAIL" ]; then
+        email_args="--email $CERTBOT_EMAIL"
+    else
+        email_args="--register-unsafely-without-email"
+    fi
+
     $certbot_cmd $debug_flag certonly \
         --dns-cloudflare \
         --dns-cloudflare-credentials "$CLOUDFLARE_CREDENTIALS_FILE" \
         --dns-cloudflare-propagation-seconds "$CLOUDFLARE_PROPAGATION_SECONDS" \
         -d "$CERTBOT_DOMAINS" \
         --key-type "$CERTBOT_KEY_TYPE" \
-        --email "$CERTBOT_EMAIL" \
+        $email_args \
         --server "$CERTBOT_SERVER" \
         --agree-tos \
         --non-interactive \
@@ -140,7 +201,7 @@ run_certbot() {
 
 validate_environment_variables() {
     # Validate required environment variables
-    for var in CLOUDFLARE_API_TOKEN CERTBOT_DOMAINS CERTBOT_EMAIL CERTBOT_KEY_TYPE CERTBOT_SERVER CLOUDFLARE_CREDENTIALS_FILE CLOUDFLARE_PROPAGATION_SECONDS; do
+    for var in CLOUDFLARE_API_TOKEN CERTBOT_DOMAINS CERTBOT_KEY_TYPE CERTBOT_SERVER CLOUDFLARE_CREDENTIALS_FILE CLOUDFLARE_PROPAGATION_SECONDS; do
         if [ -z "$(eval echo \$$var)" ]; then
             echo "Error: $var environment variable is not set"
             exit 1
@@ -160,6 +221,8 @@ if [ -n "$CERTBOT_DOMAIN" ] && [ -z "$CERTBOT_DOMAINS" ]; then
 fi
 
 validate_environment_variables
+
+configure_proxychains
 
 if ! is_default_privileges; then
     configure_uid_and_gid


### PR DESCRIPTION
Summary
- Add configurable proxy support so Certbot traffic can be routed through SOCKS/HTTP proxies using `proxychains4`.
- Make `CERTBOT_EMAIL` optional while still allowing non-interactive operation.
- Document the new behavior and configuration options in the README.

Changes
- Introduced new environment variables:
  - `PROXY_TYPE` (supported: `none`, `socks5`, `socks4`, `http`, `https`)
  - `PROXY_HOST`
  - `PROXY_PORT`
  - `PROXY_USERNAME`
  - `PROXY_PASSWORD`
- Updated `entrypoint.sh` to:
  - Validate `PROXY_TYPE` and require `PROXY_HOST` / `PROXY_PORT` when a proxy is enabled.
  - Generate `/etc/proxychains/proxychains.conf` from the proxy env vars (including optional auth).
  - Automatically wrap the Certbot command with `proxychains4` when `PROXY_TYPE != none`.
- Adjusted Certbot invocation:
  - If `CERTBOT_EMAIL` is set, pass `--email $CERTBOT_EMAIL`.
  - If `CERTBOT_EMAIL` is empty, use `--register-unsafely-without-email` to keep it non-interactive.
- Updated `README.md`:
  - Marked `CERTBOT_EMAIL` as optional and documented the fallback behavior.
  - Added descriptions for the new proxy-related environment variables and valid proxy types.

Notes
- Default behavior (no proxy, email provided) remains unchanged.
- When a proxy is configured, all Certbot ACME traffic is routed through the configured proxy via `proxychains4`.